### PR TITLE
Relax pyproject requirements to allow install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,11 @@ name = "map-maker"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11.11"
 dependencies = [
     "matplotlib>=3.10.3",
     "pandas>=2.3.0",
     "pillow>=11.2.1",
 ]
+[tool.setuptools]
+py-modules = []


### PR DESCRIPTION
The Python version and directory layout prevented installation.

In particular, the pyproject.toml file was amended to address the following error:

error: Multiple top-level packages discovered in a flat-layout: ['hex_grid', 'py_script', 'made_maps', 'pixel_image', 'hex_grid_png'].